### PR TITLE
Revert Selective Errors range to original

### DIFF
--- a/lib/faraday/conductivity/selective_errors.rb
+++ b/lib/faraday/conductivity/selective_errors.rb
@@ -59,7 +59,7 @@ module Faraday
 
       def initialize(app, options = {})
         @app    = app
-        @on     = options.fetch(:on) { ClientErrorStatuses }
+        @on     = options.fetch(:on) { ClientErrorStatuses.to_a + ServerErrorStatuses.to_a }
         @except = options.fetch(:except) { [] }
       end
 


### PR DESCRIPTION
The SelectiveErrors default range used to include the statuses 500..600, since they were all considered "ClientError" statuses.

After Faraday 1.0.0 changes (#1), need to update the default range to explicitly include the 500..600 range that was separated out into ServerErrorStatuses.